### PR TITLE
fix: update selectors for events

### DIFF
--- a/src/store/modules/event.ts
+++ b/src/store/modules/event.ts
@@ -38,7 +38,7 @@ export const eventStore = defineStore({
     loading: false,
     events: [],
     total: 0,
-    services: [{ value: "", label: "" }],
+    services: [{ value: "", label: "All" }],
     instances: [{ value: "", label: "All" }],
     endpoints: [{ value: "", label: "All" }],
     condition: {
@@ -51,6 +51,10 @@ export const eventStore = defineStore({
       this.condition = { ...this.condition, ...data };
     },
     async getServices(layer: string) {
+      if (!layer) {
+        this.services = [{ value: "", label: "All" }];
+        return new Promise((resolve) => resolve([]));
+      }
       const res: AxiosResponse = await graphql.query("queryServices").params({
         layer,
       });

--- a/src/views/event/Header.vue
+++ b/src/views/event/Header.vue
@@ -124,9 +124,6 @@ getSelectors();
 
 async function getSelectors() {
   await getLayers();
-  if (!state.currentLayer) {
-    return;
-  }
   getServices();
 }
 
@@ -169,10 +166,13 @@ async function getLayers() {
     ElMessage.error(resp.errors);
     return;
   }
-  state.currentLayer = resp.data.layers[0] || "";
-  state.layers = resp.data.layers.map((d: string) => {
-    return { label: d, value: d };
-  });
+  state.currentLayer = "";
+  state.layers = [
+    { label: "All", value: "" },
+    ...resp.data.layers.map((d: string) => {
+      return { label: d, value: d };
+    }),
+  ];
 }
 
 async function queryEvents() {


### PR DESCRIPTION
Add  an `all` option in layer selector for events.

Screenshot

<img width="1450" alt="1" src="https://user-images.githubusercontent.com/20871783/157582615-fac74e4e-63ff-42fc-bda1-6ca6ffa11780.png">

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

