### PR TITLE
Add `/node` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .DS_Store
 node_modules
 /dist
+/node
 
 /tests/e2e/videos/
 /tests/e2e/screenshots/


### PR DESCRIPTION
This folder will be used to download npm in the main repo build. So, it is better to ignore this path.