### PR TITLE
fix: add the alarm and log tag tips

### DIFF
--- a/src/locales/lang/en.ts
+++ b/src/locales/lang/en.ts
@@ -242,6 +242,10 @@ const msg = {
   defaultDepth: "Default Depth",
   traceTagsTip: `Only tags defined in the core/default/searchableTracesTags are searchable.
   Check more details on the Configuration Vocabulary page`,
+  logTagsTip: `Only tags defined in the core/default/searchableLogsTags are searchable.
+  Check more details on the Configuration Vocabulary page`,
+  alarmTagsTip: `Only tags defined in the core/default/searchableAlarmTags are searchable.
+  Check more details on the Configuration Vocabulary page`,
   tagsLink: "Configuration Vocabulary page",
   addTag: "Please input a tag",
   log: "Log",

--- a/src/locales/lang/zh.ts
+++ b/src/locales/lang/zh.ts
@@ -243,6 +243,10 @@ const msg = {
   defaultDepth: "默认深度",
   traceTagsTip:
     "只有core/default/searchableTracesTags中定义的标记才可搜索。查看配置词汇表页面上的更多详细信息。",
+  logTagsTip:
+    "只有core/default/searchableTracesTags中定义的标记才可搜索。查看配置词汇表页面上的更多详细信息。",
+  alarmTagsTip:
+    "只有core/default/searchableTracesTags中定义的标记才可搜索。查看配置词汇表页面上的更多详细信息。",
   tagsLink: "配置词汇页",
   addTag: "请添加标签",
   logCategory: "日志类别",

--- a/src/views/components/ConditionTags.vue
+++ b/src/views/components/ConditionTags.vue
@@ -39,7 +39,17 @@ limitations under the License. -->
         >
           {{ t("tagsLink") }}
         </a>
-        <el-tooltip :content="t('traceTagsTip')">
+        <el-tooltip
+          :content="
+            t(
+              type === 'LOG'
+                ? 'logTagsTip'
+                : type === 'TRACE'
+                ? 'traceTagsTip'
+                : 'alarmTagsTip'
+            )
+          "
+        >
           <span>
             <Icon class="icon-help mr-5" iconName="help" size="middle" />
           </span>


### PR DESCRIPTION
Add the alarm and log tag tips.

screenshots

<img width="1436" alt="1" src="https://user-images.githubusercontent.com/20871783/165896550-1ce4b711-2f2e-46a5-837f-ba2986de2515.png">

<img width="1414" alt="2" src="https://user-images.githubusercontent.com/20871783/165896584-14343bad-48cb-4876-bdab-6be4d8c926df.png">

<img width="1418" alt="3" src="https://user-images.githubusercontent.com/20871783/165896600-4cb6e701-30c4-40c4-8665-41b526d1bb02.png">


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

