### PR TITLE
fix: view spans details and task logs

### DIFF
--- a/src/store/modules/profile.ts
+++ b/src/store/modules/profile.ts
@@ -161,7 +161,13 @@ export const profileStore = defineStore({
         this.analyzeTrees = [];
         return res.data;
       }
-      this.segmentSpans = segment.spans;
+      this.segmentSpans = segment.spans.map((d: SegmentSpan) => {
+        return {
+          ...d,
+          segmentId: this.currentSegment.segmentId,
+          traceId: this.currentSegment.traceIds[0],
+        };
+      });
       if (!(segment.spans && segment.spans.length)) {
         this.analyzeTrees = [];
         return res.data;

--- a/src/views/dashboard/related/components/LogTable/LogService.vue
+++ b/src/views/dashboard/related/components/LogTable/LogService.vue
@@ -22,12 +22,12 @@ limitations under the License. -->
       <span v-else-if="item.label === 'tags'">
         {{ tags }}
       </span>
-      <router-link
+      <!-- <router-link
         v-else-if="item.label === 'traceId' && !noLink"
         :to="{ name: 'trace', query: { traceid: data[item.label] } }"
       >
         <span :class="noLink ? '' : 'blue'">{{ data[item.label] }}</span>
-      </router-link>
+      </router-link> -->
       <span v-else>{{ data[item.label] }}</span>
     </div>
   </div>

--- a/src/views/dashboard/related/profile/components/TaskList.vue
+++ b/src/views/dashboard/related/profile/components/TaskList.vue
@@ -124,12 +124,14 @@ limitations under the License. -->
 import { ref } from "vue";
 import dayjs from "dayjs";
 import { useI18n } from "vue-i18n";
+import { useSelectorStore } from "@/store/modules/selectors";
 import { useProfileStore } from "@/store/modules/profile";
 import { TaskLog, TaskListItem } from "@/types/profile";
 import { ElMessage } from "element-plus";
 
 const { t } = useI18n();
 const profileStore = useProfileStore();
+const selectorStore = useSelectorStore();
 const dateFormat = (date: number, pattern = "YYYY-MM-DD HH:mm:ss") =>
   dayjs(date).format(pattern);
 const viewDetail = ref<boolean>(false);
@@ -150,7 +152,7 @@ async function viewTask(e: Event, item: TaskListItem) {
   viewDetail.value = true;
   selectedTask.value = item;
   service.value = (
-    profileStore.services.filter((s: any) => s.id === item.serviceId)[0] || {}
+    selectorStore.services.filter((s: any) => s.id === item.serviceId)[0] || {}
   ).label;
   const res = await profileStore.getTaskLogs({ taskID: item.id });
 

--- a/src/views/dashboard/related/trace/components/D3Graph/SpanDetail.vue
+++ b/src/views/dashboard/related/trace/components/D3Graph/SpanDetail.vue
@@ -40,7 +40,7 @@ limitations under the License. -->
       <span class="g-sm-8 wba">{{ currentSpan.peer || "No Peer" }}</span>
     </div>
     <div class="mb-10 clear item">
-      <span class="g-sm-4 grey">{{ t("error") }}:</span>
+      <span class="g-sm-4 grey">{{ t("isError") }}:</span>
       <span class="g-sm-8 wba">{{ currentSpan.isError }}</span>
     </div>
     <div class="mb-10 clear item" v-for="i in currentSpan.tags" :key="i.key">

--- a/src/views/dashboard/related/trace/components/Table/TableItem.vue
+++ b/src/views/dashboard/related/trace/components/Table/TableItem.vue
@@ -106,7 +106,7 @@ limitations under the License. -->
         </el-tooltip>
       </div>
       <div class="application" v-show="headerType === 'profile'">
-        <span @click="viewSpanDetail">{{ t("view") }}</span>
+        <span @click="viewSpan($event)">{{ t("view") }}</span>
       </div>
     </div>
     <div
@@ -139,6 +139,7 @@ import { useI18n } from "vue-i18n";
 import { ref, computed, defineComponent } from "vue";
 import type { PropType } from "vue";
 import SpanDetail from "../D3Graph/SpanDetail.vue";
+import { ClickHandler } from "d3-flame-graph";
 
 const props = {
   data: { type: Object as PropType<any>, default: () => ({}) },
@@ -185,7 +186,7 @@ export default defineComponent({
     function toggle() {
       displayChildren.value = !displayChildren.value;
     }
-    function showSelectSpan(dom: any) {
+    function showSelectSpan(dom: HTMLSpanElement) {
       if (!dom) {
         return;
       }
@@ -196,6 +197,7 @@ export default defineComponent({
       dom.style.background = "rgba(0, 0, 0, 0.1)";
     }
     function selectSpan(event: any) {
+      console.log(event);
       const dom = event.path.find((d: any) =>
         d.className.includes("trace-item")
       );
@@ -207,11 +209,18 @@ export default defineComponent({
       }
       viewSpanDetail(dom);
     }
+    function viewSpan(event: any) {
+      const dom = event.path.find((d: any) =>
+        d.className.includes("trace-item")
+      );
+      emit("select", props.data);
+      viewSpanDetail(dom);
+    }
 
-    function selectedItem(data: any) {
+    function selectedItem(data: HTMLSpanElement) {
       emit("select", data);
     }
-    function viewSpanDetail(dom: any) {
+    function viewSpanDetail(dom: HTMLSpanElement) {
       showSelectSpan(dom);
       showDetail.value = true;
     }
@@ -226,6 +235,7 @@ export default defineComponent({
       showDetail,
       selectSpan,
       selectedItem,
+      viewSpan,
       t,
     };
   },

--- a/src/views/dashboard/related/trace/components/Table/TableItem.vue
+++ b/src/views/dashboard/related/trace/components/Table/TableItem.vue
@@ -105,8 +105,12 @@ limitations under the License. -->
           <span>{{ data.serviceCode }}</span>
         </el-tooltip>
       </div>
-      <div class="application" v-show="headerType === 'profile'">
-        <span @click="viewSpan($event)">{{ t("view") }}</span>
+      <div
+        class="application"
+        v-show="headerType === 'profile'"
+        @click="viewSpan($event)"
+      >
+        <span>{{ t("view") }}</span>
       </div>
     </div>
     <div
@@ -139,7 +143,6 @@ import { useI18n } from "vue-i18n";
 import { ref, computed, defineComponent } from "vue";
 import type { PropType } from "vue";
 import SpanDetail from "../D3Graph/SpanDetail.vue";
-import { ClickHandler } from "d3-flame-graph";
 
 const props = {
   data: { type: Object as PropType<any>, default: () => ({}) },
@@ -197,7 +200,6 @@ export default defineComponent({
       dom.style.background = "rgba(0, 0, 0, 0.1)";
     }
     function selectSpan(event: any) {
-      console.log(event);
       const dom = event.path.find((d: any) =>
         d.className.includes("trace-item")
       );


### PR DESCRIPTION
Fixes the span details and task logs on the profile widget.

Screenshots

<img width="1540" alt="2" src="https://user-images.githubusercontent.com/20871783/166631324-5029c8d4-81fe-4143-8295-dd238b3a4d32.png">

<img width="779" alt="5" src="https://user-images.githubusercontent.com/20871783/166631534-02816a66-2b2b-4dbf-a4cd-32e4bcd1c160.png">


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

