### PR TITLE
fix: activate the correct tab index after renaming a Tabs name

### DIFF
--- a/src/store/modules/demand-log.ts
+++ b/src/store/modules/demand-log.ts
@@ -1,4 +1,3 @@
-import { ElMessage } from "element-plus";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/views/dashboard/panel/Layout.vue
+++ b/src/views/dashboard/panel/Layout.vue
@@ -29,7 +29,7 @@ limitations under the License. -->
       :h="item.h"
       :i="item.i"
       :key="item.i"
-      @click="clickGrid(item)"
+      @click="clickGrid(item, $event)"
       :class="{ active: dashboardStore.activedGridItem === item.i }"
       :drag-ignore-from="dragIgnoreFrom"
     >
@@ -55,10 +55,13 @@ export default defineComponent({
     const dashboardStore = useDashboardStore();
     const selectorStore = useSelectorStore();
 
-    function clickGrid(item: LayoutConfig) {
+    function clickGrid(item: LayoutConfig, event: Event) {
       dashboardStore.activeGridItem(item.i);
       dashboardStore.selectWidget(item);
-      if (item.type === "Tab") {
+      if (
+        item.type === "Tab" &&
+        (event.target as HTMLDivElement)?.className !== "tab-layout"
+      ) {
         dashboardStore.setActiveTabIndex(0);
       }
     }

--- a/src/views/dashboard/panel/Tool.vue
+++ b/src/views/dashboard/panel/Tool.vue
@@ -80,7 +80,7 @@ limitations under the License. -->
     </div>
     <div class="flex-h tools" v-loading="loading" v-if="!appStore.isMobile">
       <div class="tool-icons flex-h" v-if="dashboardStore.editMode">
-        <el-dropdown content="Controls" placement="bottom">
+        <el-dropdown content="Controls" placement="bottom" :persistent="false">
           <i>
             <Icon class="icon-btn" size="sm" iconName="control" />
           </i>

--- a/src/views/dashboard/related/ebpf/components/EBPFSchedules.vue
+++ b/src/views/dashboard/related/ebpf/components/EBPFSchedules.vue
@@ -40,7 +40,12 @@ limitations under the License. -->
         @change="changeAggregateType"
         class="selector mr-10"
       />
-      <el-popover placement="bottom" :width="680" trigger="click">
+      <el-popover
+        placement="bottom"
+        :width="680"
+        trigger="click"
+        :persistent="false"
+      >
         <template #reference>
           <el-button type="primary" size="small">
             {{ t("processSelect") }}


### PR DESCRIPTION
Fixes activate the correct tab index after renaming a Tabs name.

Video 

https://user-images.githubusercontent.com/20871783/172124240-8d62eeac-3ebf-477f-b4e3-ad69235f5597.mov


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

