### PR TITLE
fix: set the duration and scroll position for on-demand logs

### DIFF
--- a/src/graphql/fragments/demand-log.ts
+++ b/src/graphql/fragments/demand-log.ts
@@ -30,8 +30,6 @@ export const queryStreamingLogs = {
   logs: ondemandPodLogs(condition: $condition) {
     errorReason
     logs {
-      timestamp
-      contentType
       content
     }
   }`,

--- a/src/store/modules/demand-log.ts
+++ b/src/store/modules/demand-log.ts
@@ -31,6 +31,7 @@ interface DemandLogState {
   logs: Log[];
   loadLogs: boolean;
   message: string;
+  total: number;
 }
 
 export const demandLogStore = defineStore({
@@ -47,6 +48,7 @@ export const demandLogStore = defineStore({
     logs: [],
     loadLogs: false,
     message: "",
+    total: 0,
   }),
   actions: {
     setLogCondition(data: Conditions) {
@@ -109,6 +111,7 @@ export const demandLogStore = defineStore({
         this.setLogs("", res.data.data.logs.errorReason);
         return res.data;
       }
+      this.total = res.data.data.logs.logs.length;
       const logs = res.data.data.logs.logs
         .map((d: Log) => d.content)
         .join("\n");

--- a/src/views/dashboard/related/demand-log/Content.vue
+++ b/src/views/dashboard/related/demand-log/Content.vue
@@ -31,20 +31,25 @@ const demandLogStore = useDemandLogStore();
 const monacoInstance = ref();
 const logContent = ref<Nullable<HTMLDivElement>>(null);
 
-onMounted(async () => {
+onMounted(() => {
+  init();
+});
+async function init() {
   const monaco = await import("monaco-editor");
   monacoInstanceGen(monaco);
   window.addEventListener("resize", () => {
     editorLayout();
   });
-});
+}
 function monacoInstanceGen(monaco: any) {
   monacoInstance.value = monaco.editor.create(logContent.value, {
     value: "",
     language: "text",
     wordWrap: true,
     minimap: { enabled: false },
+    readonly: true,
   });
+  toRaw(monacoInstance.value).updateOptions({ readOnly: true });
 }
 function editorLayout() {
   if (!logContent.value) {
@@ -66,7 +71,19 @@ onUnmounted(() => {
 watch(
   () => demandLogStore.logs,
   () => {
+    if (!toRaw(monacoInstance.value)) {
+      return;
+    }
     toRaw(monacoInstance.value).setValue(demandLogStore.logs);
+    if (!demandLogStore.logs) {
+      return;
+    }
+    setTimeout(() => {
+      toRaw(monacoInstance.value).revealPosition({
+        column: 1,
+        lineNumber: demandLogStore.total,
+      });
+    }, 1000);
   }
 );
 </script>

--- a/src/views/dashboard/related/demand-log/Header.vue
+++ b/src/views/dashboard/related/demand-log/Header.vue
@@ -165,21 +165,23 @@ const state = reactive<any>({
 });
 /*global Nullable */
 const intervalFn = ref<Nullable<any>>(null);
-const rangeTime = computed(() => {
-  const times = {
-    start: getLocalTime(
-      appStore.utc,
-      new Date(new Date().getTime() - state.duration.value * 1000)
-    ),
-    end: getLocalTime(appStore.utc, new Date()),
-    step: "SECOND",
-  };
-  return {
-    start: dateFormatStep(times.start, times.step, false),
-    end: dateFormatStep(times.end, times.step, false),
-    step: times.step,
-  };
-});
+function rangeTime() {
+  {
+    const times = {
+      start: getLocalTime(
+        appStore.utc,
+        new Date(new Date().getTime() - state.duration.value * 1000)
+      ),
+      end: getLocalTime(appStore.utc, new Date()),
+      step: "SECOND",
+    };
+    return {
+      start: dateFormatStep(times.start, times.step, false),
+      end: dateFormatStep(times.end, times.step, false),
+      step: times.step,
+    };
+  }
+}
 
 onMounted(() => {
   fetchSelectors();
@@ -236,7 +238,7 @@ function searchLogs() {
   demandLogStore.setLogCondition({
     serviceInstanceId: instance || state.instance.id || "",
     container: state.container.value,
-    duration: rangeTime.value,
+    duration: rangeTime(),
     keywordsOfContent: keywordsOfContent.value.length
       ? keywordsOfContent.value
       : undefined,

--- a/src/views/dashboard/related/demand-log/Header.vue
+++ b/src/views/dashboard/related/demand-log/Header.vue
@@ -110,11 +110,6 @@ limitations under the License. -->
         v-model="excludingContentStr"
         @change="addLabels('excludingKeywordsOfContent')"
       />
-      <el-tooltip :content="t('keywordsOfContentLogTips')">
-        <span class="log-tips">
-          <Icon size="middle" iconName="help" class="ml-5 help" />
-        </span>
-      </el-tooltip>
     </div>
   </div>
   <div class="flex-h row btn-row">


### PR DESCRIPTION
Set the duration and scroll position for on-demand logs.

Video 

https://user-images.githubusercontent.com/20871783/172373685-675df8a0-3834-4cb5-a569-702cc4f62f30.mov


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

