### PR TITLE
fix: SpanDetail text overlap

### DIFF
--- a/src/views/dashboard/related/trace/components/D3Graph/SpanDetail.vue
+++ b/src/views/dashboard/related/trace/components/D3Graph/SpanDetail.vue
@@ -166,7 +166,7 @@ function showCurrentSpanDetail(text: string) {
 }
 
 .item span {
-  height: 21px;
+  min-height: 21px;
 }
 
 .link-hover {


### PR DESCRIPTION
before:
<img width="1169" alt="image" src="https://user-images.githubusercontent.com/32632779/174990977-d96e6108-1f6b-4960-96d9-4172e7bee960.png">
after:
<img width="1154" alt="image" src="https://user-images.githubusercontent.com/32632779/174990865-0ebb37c6-268d-4af0-9662-ac309f545dbc.png">
