### PR TITLE
fix: set the value(SECOND) of the `step` filed for queries

### DIFF
--- a/src/views/dashboard/related/event/Content.vue
+++ b/src/views/dashboard/related/event/Content.vue
@@ -139,7 +139,19 @@ function associateTraceLog(
       };
       dashboardStore.setWidget(item);
     } else {
-      const { start, end } = setEndTime(i.start, i.end);
+      let step = appStore.duration.step;
+      let start = i.start;
+      let end = i.end;
+      if (
+        appStore.duration.step === "MINUTE" &&
+        i.end.getTime() - i.start.getTime() < 60000
+      ) {
+        step = "SECOND";
+      } else {
+        const times = setEndTime(i.start, i.end);
+        start = times.start;
+        end = times.end;
+      }
       const item = {
         ...widget,
         filters: {
@@ -147,15 +159,11 @@ function associateTraceLog(
           duration: {
             start: dateFormatStep(
               getLocalTime(appStore.utc, start),
-              appStore.duration.step,
+              step,
               true
             ),
-            end: dateFormatStep(
-              getLocalTime(appStore.utc, end),
-              appStore.duration.step,
-              true
-            ),
-            step: appStore.duration.step,
+            end: dateFormatStep(getLocalTime(appStore.utc, end), step, true),
+            step,
           },
         },
       };

--- a/src/views/dashboard/related/log/Header.vue
+++ b/src/views/dashboard/related/log/Header.vue
@@ -271,7 +271,7 @@ function searchLogs() {
         : state.service.id,
       endpointId: endpoint || state.endpoint.id || undefined,
       serviceInstanceId: instance || state.instance.id || undefined,
-      queryDuration: appStore.durationTime,
+      queryDuration: duration.value,
       keywordsOfContent: keywordsOfContent.value,
       excludingKeywordsOfContent: excludingKeywordsOfContent.value,
       tags: tagsMap.value.length ? tagsMap.value : undefined,

--- a/src/views/dashboard/related/log/Header.vue
+++ b/src/views/dashboard/related/log/Header.vue
@@ -344,13 +344,6 @@ function removeExcludeContent(index: number) {
 }
 onUnmounted(() => {
   logStore.resetState();
-  const item = {
-    ...props.data,
-    filters: undefined,
-  };
-  dashboardStore.setWidget(item);
-  traceId.value = "";
-  duration.value = appStore.durationTime;
 });
 watch(
   () => selectorStore.currentService,

--- a/src/views/dashboard/related/trace/Filter.vue
+++ b/src/views/dashboard/related/trace/Filter.vue
@@ -236,13 +236,6 @@ async function searchEndpoints(keyword: string) {
 }
 onUnmounted(() => {
   traceStore.resetState();
-  const item = {
-    ...props.data,
-    filters: undefined,
-  };
-  dashboardStore.setWidget(item);
-  traceId.value = "";
-  duration.value = appStore.durationTime;
 });
 watch(
   () => [selectorStore.currentPod],


### PR DESCRIPTION
Set the value of the `step` filed for trace and log queries when the event widget associates with the trace and log widgets.

Video 

https://user-images.githubusercontent.com/20871783/181761867-5e47bc1e-21d0-4a36-a06d-80f2bb0a92d5.mov


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
