### PR TITLE
feat: add `readRecords` to metric types

### DIFF
--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -21,6 +21,7 @@ export enum MetricQueryTypes {
   ReadLabeledMetricsValues = "readLabeledMetricsValues",
   READHEATMAP = "readHeatMap",
   ReadSampledRecords = "readSampledRecords",
+  ReadRecords = "readRecords",
 }
 
 export enum Calculations {
@@ -97,6 +98,12 @@ export const RespFields: any = {
     }
   }`,
   readSampledRecords: `{
+    name
+    value
+    refId
+  }`,
+  readRecords: `{
+    id
     name
     value
     refId

--- a/src/hooks/useProcessor.ts
+++ b/src/hooks/useProcessor.ts
@@ -56,8 +56,8 @@ export function useQueryProcessor(config: any) {
     const c = (config.metricConfig && config.metricConfig[index]) || {};
     if (
       [
-        MetricQueryTypes.ReadSampledRecords,
         MetricQueryTypes.SortMetrics,
+        MetricQueryTypes.ReadSampledRecords,
       ].includes(metricType)
     ) {
       variables.push(`$condition${index}: TopNCondition!`);
@@ -70,6 +70,22 @@ export function useQueryProcessor(config: any) {
           ? selectorStore.currentService.normal
           : true,
         scope: config.catalog,
+        topN: c.topN || 10,
+        order: c.sortOrder || "DES",
+      };
+    } else if ([MetricQueryTypes.ReadRecords].includes(metricType)) {
+      variables.push(`$condition${index}: RecordCondition!`);
+      conditions[`condition${index}`] = {
+        name,
+        parentEntity: {
+          scope: config.catalog,
+          normal: selectorStore.currentService
+            ? selectorStore.currentService.normal
+            : true,
+          serviceName: ["All"].includes(dashboardStore.entity)
+            ? null
+            : selectorStore.currentService.value,
+        },
         topN: c.topN || 10,
         order: c.sortOrder || "DES",
       };
@@ -435,6 +451,7 @@ export async function useGetMetricEntity(metric: string, metricType: any) {
     [
       MetricQueryTypes.ReadSampledRecords,
       MetricQueryTypes.SortMetrics,
+      MetricQueryTypes.ReadRecords,
     ].includes(metricType)
   ) {
     const res = await dashboardStore.fetchMetricList(metric);

--- a/src/hooks/useProcessor.ts
+++ b/src/hooks/useProcessor.ts
@@ -56,8 +56,8 @@ export function useQueryProcessor(config: any) {
     const c = (config.metricConfig && config.metricConfig[index]) || {};
     if (
       [
-        MetricQueryTypes.SortMetrics,
         MetricQueryTypes.ReadSampledRecords,
+        MetricQueryTypes.SortMetrics,
       ].includes(metricType)
     ) {
       variables.push(`$condition${index}: TopNCondition!`);

--- a/src/views/dashboard/data.ts
+++ b/src/views/dashboard/data.ts
@@ -45,6 +45,7 @@ export const MetricChartType: any = {
   readLabeledMetricsValues: [{ label: "Line", value: "Line" }],
   readHeatMap: [{ label: "Heat Map", value: "HeatMap" }],
   readSampledRecords: [{ label: "Top List", value: "TopList" }],
+  readRecords: [{ label: "Top List", value: "TopList" }],
 };
 export const DefaultGraphConfig: { [key: string]: any } = {
   Bar: {
@@ -134,6 +135,7 @@ export const MetricTypes: {
     { label: "read heatmap values in the duration", value: "readHeatMap" },
   ],
   SAMPLED_RECORD: [
+    { label: "get sorted topN values", value: "readRecords" },
     { label: "get sorted topN values", value: "readSampledRecords" },
   ],
 };


### PR DESCRIPTION
According to https://github.com/apache/skywalking-query-protocol/pull/100/files, add `readRecords` to metric types.

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
