### PR TITLE
fix: avoid being unable to drag process nodes for the first time

### DIFF
--- a/src/views/dashboard/related/network-profiling/components/ProcessTopology.vue
+++ b/src/views/dashboard/related/network-profiling/components/ProcessTopology.vue
@@ -324,7 +324,9 @@ limitations under the License. -->
     const drag: any = d3.drag().on("drag", (d: ProcessNode) => {
       moveNode(d);
     });
-    d3.selectAll(".node").call(drag);
+    setTimeout(() => {
+      d3.selectAll(".node").call(drag);
+    }, 1000);
   }
 
   function shuffleArray(array: number[][]) {


### PR DESCRIPTION
Avoids being unable to drag process nodes for the first time.

Video 

https://user-images.githubusercontent.com/20871783/208623596-3e10ef44-dd41-43ef-bd1e-af03feccfaa9.mov


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
