### PR TITLE
Add node folder into ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+node
 node_modules
 .DS_Store
 dist


### PR DESCRIPTION
In the main repository build, I can see the node is downloaded in the `/skywalking-ui/node` listed in the git 

<img width="473" alt="image" src="https://user-images.githubusercontent.com/5441976/209746425-5d4e9b51-34f6-4f41-bb29-07a1f06b3ae1.png">

