### PR TITLE
fix: Formatted display of json content type

### DIFF
--- a/src/views/dashboard/related/log/LogTable/LogDetail.vue
+++ b/src/views/dashboard/related/log/LogTable/LogDetail.vue
@@ -23,9 +23,7 @@ limitations under the License. -->
         class="content mb-10"
         :readonly="true"
         v-else-if="item.label === 'content'"
-        :value="
-          currentLog.contentType === 'JSON' ? formatJson(JSON.parse(currentLog[item.label])) : currentLog[item.label]
-        "
+        :value="contentFormat(item.label)"
       />
       <span v-else-if="item.label === 'tags'" class="g-sm-8 mb-10">
         <div v-for="(d, index) in logTags" :key="index">{{ d }}</div>
@@ -56,6 +54,16 @@ limitations under the License. -->
       return `${d.key} = ${d.value}`;
     });
   });
+
+  function contentFormat(label: string) {
+    try {
+      return props.currentLog.contentType === "JSON"
+        ? formatJson(JSON.parse(props.currentLog[label]))
+        : props.currentLog[label];
+    } catch (e) {
+      return props.currentLog[label];
+    }
+  }
 </script>
 <style lang="scss" scoped>
   .content {

--- a/src/views/dashboard/related/log/LogTable/LogDetail.vue
+++ b/src/views/dashboard/related/log/LogTable/LogDetail.vue
@@ -23,7 +23,9 @@ limitations under the License. -->
         class="content mb-10"
         :readonly="true"
         v-else-if="item.label === 'content'"
-        :value="currentLog[item.label]"
+        :value="
+          currentLog.contentType === 'JSON' ? formatJson(JSON.parse(currentLog[item.label])) : currentLog[item.label]
+        "
       />
       <span v-else-if="item.label === 'tags'" class="g-sm-8 mb-10">
         <div v-for="(d, index) in logTags" :key="index">{{ d }}</div>
@@ -38,6 +40,7 @@ limitations under the License. -->
   import { useI18n } from "vue-i18n";
   import type { Option } from "@/types/app";
   import { dateFormat } from "@/utils/dateFormat";
+  import { formatJson } from "@/utils/formatJson";
 
   /*global defineProps */
   const props = defineProps({


### PR DESCRIPTION
The version before 8.8.0 is correct, and there are mistake after 8.8.0.

Expect
![image](https://user-images.githubusercontent.com/5037807/212642366-61a448d9-cf07-4cb6-80bc-5149cadb14dc.png)

Actual
![image](https://user-images.githubusercontent.com/5037807/212642660-c5b6958a-4b1b-44cb-9ee8-c9b512c2f43f.png)

https://github.com/apache/skywalking-rocketbot-ui/pull/572
