### PR TITLE
build: bump postcss to a non-vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13626,7 +13626,7 @@
         "loader-utils": "^1.1.0",
         "merge-options": "1.0.1",
         "micromatch": "3.1.0",
-        "postcss": "^5.2.17",
+        "postcss": "^7.0.36",
         "postcss-prefix-selector": "^1.6.0",
         "posthtml-rename-id": "^1.0",
         "posthtml-svg-mode": "^1.0.3",
@@ -13789,8 +13789,8 @@
       }
     },
     "node_modules/svg-baker/node_modules/postcss": {
-      "version": "5.2.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "dev": true,
       "dependencies": {
@@ -26176,7 +26176,7 @@
         "loader-utils": "^1.1.0",
         "merge-options": "1.0.1",
         "micromatch": "3.1.0",
-        "postcss": "^5.2.17",
+        "postcss": "^7.0.36",
         "postcss-prefix-selector": "^1.6.0",
         "posthtml-rename-id": "^1.0",
         "posthtml-svg-mode": "^1.0.3",
@@ -26307,8 +26307,8 @@
           }
         },
         "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "version": "7.0.36",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13791,7 +13791,7 @@
     "node_modules/svg-baker/node_modules/postcss": {
       "version": "7.0.36",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
@@ -26309,7 +26309,7 @@
         "postcss": {
           "version": "7.0.36",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",


### PR DESCRIPTION
Fixes https://github.com/apache/skywalking-booster-ui/security/dependabot/16

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
