### PR TITLE
feat: add calculations for the `cpm5dAvg`

### DIFF
--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -39,6 +39,7 @@ export enum Calculations {
   SecondToDay = "secondToDay",
   NanosecondToMillisecond = "nanosecondToMillisecond",
   CPM5D = "cpm5d",
+  CPM5DAvg = "cpm5dAvg",
 }
 export enum sizeEnum {
   XS = "XS",

--- a/src/hooks/useListConfig.ts
+++ b/src/hooks/useListConfig.ts
@@ -17,7 +17,7 @@
 import { MetricQueryTypes, Calculations } from "./data";
 export function useListConfig(config: any, index: string) {
   const i = Number(index);
-  const types = [Calculations.Average, Calculations.ApdexAvg, Calculations.PercentageAvg];
+  const types = [Calculations.Average, Calculations.ApdexAvg, Calculations.PercentageAvg, Calculations.CPM5DAvg];
   const calculation = config.metricConfig && config.metricConfig[i] && config.metricConfig[i].calculation;
   const isLinear =
     [MetricQueryTypes.ReadMetricsValues, MetricQueryTypes.ReadLabeledMetricsValues].includes(config.metricTypes[i]) &&

--- a/src/hooks/useMetricsProcessor.ts
+++ b/src/hooks/useMetricsProcessor.ts
@@ -290,7 +290,11 @@ export function usePodsSource(
       }
       if (config.metricTypes[index] === MetricQueryTypes.ReadMetricsValues) {
         d[name] = {};
-        if ([Calculations.Average, Calculations.ApdexAvg, Calculations.PercentageAvg].includes(c.calculation)) {
+        if (
+          [Calculations.Average, Calculations.ApdexAvg, Calculations.PercentageAvg, Calculations.CPM5DAvg].includes(
+            c.calculation,
+          )
+        ) {
           d[name]["avg"] = calculateExp(resp.data[key].values.values, c);
         }
         d[name]["values"] = resp.data[key].values.values.map((val: { value: number }) => aggregation(val.value, c));
@@ -315,7 +319,11 @@ export function usePodsSource(
           if (!d[key]) {
             d[key] = {};
           }
-          if ([Calculations.Average, Calculations.ApdexAvg, Calculations.PercentageAvg].includes(c.calculation)) {
+          if (
+            [Calculations.Average, Calculations.ApdexAvg, Calculations.PercentageAvg, Calculations.CPM5DAvg].includes(
+              c.calculation,
+            )
+          ) {
             d[key]["avg"] = calculateExp(item.values.values, c);
           }
           d[key]["values"] = values;
@@ -369,6 +377,13 @@ function calculateExp(arr: { value: number }[], config: { calculation?: string }
     case Calculations.ApdexAvg:
       data = [(sum / arr.length / 10000).toFixed(2)];
       break;
+    case Calculations.CPM5DAvg:
+      data = [
+        sum / arr.length / 100000 < 1 && sum / arr.length / 100000 !== 0
+          ? (sum / arr.length / 100000).toFixed(5)
+          : (sum / arr.length / 100000).toFixed(2),
+      ];
+      break;
     default:
       data = arr.map((d) => aggregation(d.value, config));
       break;
@@ -415,6 +430,12 @@ export function aggregation(val: number, config: { calculation?: string }): numb
       break;
     case Calculations.NanosecondToMillisecond:
       data = (val / 1000 / 1000).toFixed(2);
+      break;
+    case Calculations.ApdexAvg:
+      data = (val / 10000).toFixed(2);
+      break;
+    case Calculations.CPM5DAvg:
+      data = val / 100000 < 1 && val / 100000 !== 0 ? (val / 100000).toFixed(5) : (val / 100000).toFixed(2);
       break;
     default:
       data;

--- a/src/views/dashboard/data.ts
+++ b/src/views/dashboard/data.ts
@@ -300,6 +300,7 @@ export const CalculationOpts = [
   { label: "Apdex", value: "apdex" },
   { label: "Avg-preview", value: "average" },
   { label: "Percentage + Avg-preview", value: "percentageAvg" },
+  { label: "CPM5D + Avg-preview", value: "cpm5dAvg" },
   { label: "Apdex + Avg-preview", value: "apdexAvg" },
   { label: "Byte to KB", value: "byteToKB" },
   { label: "Byte to MB", value: "byteToMB" },


### PR DESCRIPTION
Add calculations for the `cpm5dAvg`.

Video 

https://user-images.githubusercontent.com/20871783/221756396-4bf3acd4-4ab1-496d-9b03-0cae4651e2ee.mov


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
