### PR TITLE
fix: incorrect operation menu content in the topology widget

### DIFF
--- a/src/views/dashboard/related/topology/components/Graph.vue
+++ b/src/views/dashboard/related/topology/components/Graph.vue
@@ -448,6 +448,7 @@ limitations under the License. -->
     operationsPos.x = event.offsetX;
     operationsPos.y = event.offsetY;
     if (d.layer === String(dashboardStore.layerId)) {
+      setNodeTools(settings.value.nodeDashboard);
       return;
     }
     items.value = [


### PR DESCRIPTION
Fixes incorrect operation menu content in the topology widget.

Videos 

Before 

https://user-images.githubusercontent.com/20871783/227090452-eaadd020-a92e-4d4c-84b5-315517701be4.mov

After

https://user-images.githubusercontent.com/20871783/227090549-ee90d58a-43dd-413a-8422-d4b899f45e9b.mov


Signed-off-by: Qiuxia Fan<qiuxiafan@apache.org>

