### PR TITLE
fix: set filter ID when `ReadRecords` metric associates with trace 

### DIFF
--- a/src/views/dashboard/graphs/TopList.vue
+++ b/src/views/dashboard/graphs/TopList.vue
@@ -64,7 +64,7 @@ limitations under the License. -->
   import copy from "@/utils/copy";
   import { TextColors } from "@/views/dashboard/data";
   import Trace from "@/views/dashboard/related/trace/Index.vue";
-  import { QueryOrders, Status, RefIdTypes } from "../data";
+  import { QueryOrders, Status, RefIdTypes, ProtocolTypes } from "../data";
   /*global defineProps */
   const props = defineProps({
     data: {
@@ -77,6 +77,7 @@ limitations under the License. -->
       type: Object as PropType<{
         color: string;
         metrics: string[];
+        metricTypes: string[];
         relatedTrace: any;
       }>,
       default: () => ({ color: "purple" }),
@@ -112,6 +113,7 @@ limitations under the License. -->
       status: Status[2].value,
       id: item.id || item.name,
       metricValue: [{ label: props.config.metrics[0], data: item.value, value: item.name }],
+      isReadRecords: props.config.metricTypes.includes(ProtocolTypes.ReadRecords) || undefined,
     };
     traceOptions.value = {
       ...traceOptions.value,

--- a/src/views/dashboard/related/trace/Header.vue
+++ b/src/views/dashboard/related/trace/Header.vue
@@ -144,6 +144,10 @@ limitations under the License. -->
       await queryTraces();
       return;
     }
+    if (filters.isReadRecords) {
+      await queryTraces();
+      return;
+    }
     if (dashboardStore.entity === EntityType[1].value) {
       await getService();
     }


### PR DESCRIPTION
Fixes filter ID when `ReadRecords` metric associates with trace.

Video

https://user-images.githubusercontent.com/20871783/227220704-8cae1861-0638-4b39-9d18-ba2090fb8499.mov


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
