### PR TITLE
fix: detail metrics don't display with expressions in instance list

### DIFF
--- a/src/hooks/useExpressionsProcessor.ts
+++ b/src/hooks/useExpressionsProcessor.ts
@@ -129,7 +129,7 @@ export async function useExpressionsQueryProcessor(config: Indexable) {
           }
         }
         if (type === ExpressionResultType.SINGLE_VALUE) {
-          source[c.label || name] = results[0].values[0].value;
+          source[c.label || name] = (results[0].values[0] || {}).value;
         }
         if (([ExpressionResultType.RECORD_LIST, ExpressionResultType.SORTED_LIST] as string[]).includes(type)) {
           source[name] = results[0].values;
@@ -259,7 +259,7 @@ export async function useExpressionsQueryPodsMetrics(
             if (subValues) {
               d[name]["values"] = subValues;
             }
-            d[name]["avg"] = results[i].values[0].value;
+            d[name]["avg"] = (results[i].values[0] || {}).value;
 
             const j = names.find((d: string) => d === name);
 
@@ -278,7 +278,7 @@ export async function useExpressionsQueryPodsMetrics(
           if (!d[name]) {
             d[name] = {};
           }
-          d[name]["avg"] = [results[0].values[0].value];
+          d[name]["avg"] = [(results[0].values[0] || {}).value];
           if (subResults[0]) {
             if (!d[subName]) {
               d[subName] = {};

--- a/src/views/dashboard/graphs/EndpointList.vue
+++ b/src/views/dashboard/graphs/EndpointList.vue
@@ -179,9 +179,9 @@ limitations under the License. -->
       );
       endpoints.value = params.data;
       colMetrics.value = params.names;
+      colSubMetrics.value = params.subNames;
       metricTypes.value = params.metricTypesArr;
       metricConfig.value = params.metricConfigArr;
-      colSubMetrics.value = params.colSubMetrics;
       emit("expressionTips", { tips: params.expressionsTips, subTips: params.subExpressionsTips });
 
       return;
@@ -216,6 +216,7 @@ limitations under the License. -->
       ...(props.config.metrics || []),
       ...(props.config.metricConfig || []),
       ...(props.config.expressions || []),
+      ...(props.config.subExpressions || []),
       props.config.metricMode,
     ],
     (data, old) => {

--- a/src/views/dashboard/graphs/InstanceList.vue
+++ b/src/views/dashboard/graphs/InstanceList.vue
@@ -215,7 +215,7 @@ limitations under the License. -->
       );
       instances.value = params.data;
       colMetrics.value = params.names;
-      colSubMetrics.value = params.colSubMetrics;
+      colSubMetrics.value = params.subNames;
       metricTypes.value = params.metricTypesArr;
       metricConfig.value = params.metricConfigArr;
       emit("expressionTips", { tips: params.expressionsTips, subTips: params.subExpressionsTips });
@@ -268,6 +268,7 @@ limitations under the License. -->
       ...(props.config.metrics || []),
       ...(props.config.metricConfig || []),
       ...(props.config.expressions || []),
+      ...(props.config.subExpressions || []),
       props.config.metricMode,
     ],
     (data, old) => {


### PR DESCRIPTION
Screenshots

<img width="1418" alt="1" src="https://github.com/apache/skywalking-booster-ui/assets/20871783/f8f3525b-7c40-4446-a3b3-013ced5e2a18">
<img width="1415" alt="2" src="https://github.com/apache/skywalking-booster-ui/assets/20871783/c29cff96-d09d-4807-a731-99cd7c97ac69">

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
