### PR TITLE
fix: add a link to explain the expression metric, add units in the continue profiling widget

### DIFF
--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -6,6 +6,8 @@ import '@vue/runtime-core'
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     DateCalendar: typeof import('./../components/DateCalendar.vue')['default']
+    ElBreadcrumb: typeof import('element-plus/es')['ElBreadcrumb']
+    ElBreadcrumbItem: typeof import('element-plus/es')['ElBreadcrumbItem']
     ElButton: typeof import('element-plus/es')['ElButton']
     ElCollapse: typeof import('element-plus/es')['ElCollapse']
     ElCollapseItem: typeof import('element-plus/es')['ElCollapseItem']

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -6,8 +6,6 @@ import '@vue/runtime-core'
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     DateCalendar: typeof import('./../components/DateCalendar.vue')['default']
-    ElBreadcrumb: typeof import('element-plus/es')['ElBreadcrumb']
-    ElBreadcrumbItem: typeof import('element-plus/es')['ElBreadcrumbItem']
     ElButton: typeof import('element-plus/es')['ElButton']
     ElCollapse: typeof import('element-plus/es')['ElCollapse']
     ElCollapseItem: typeof import('element-plus/es')['ElCollapseItem']

--- a/src/views/dashboard/configuration/widget/metric/Index.vue
+++ b/src/views/dashboard/configuration/widget/metric/Index.vue
@@ -26,14 +26,21 @@ limitations under the License. -->
     />
   </div>
   <div>{{ t("metrics") }}</div>
-  <el-switch
-    v-model="isExpression"
-    class="mb-5"
-    active-text="Expressions"
-    inactive-text="General"
-    size="small"
-    @change="changeMetricMode"
-  />
+  <div class="flex-h">
+    <el-switch
+      v-model="isExpression"
+      class="mb-5"
+      active-text="Expressions"
+      inactive-text="General"
+      size="small"
+      @change="changeMetricMode"
+    />
+    <div class="ml-5 link">
+      <a target="_blank" href="https://skywalking.apache.org/docs/main/next/en/api/metrics-query-expression/">
+        <Icon iconName="info_outline" size="middle" />
+      </a>
+    </div>
+  </div>
   <div v-if="isExpression && states.isList">
     <span class="title">{{ t("summary") }}</span>
     <span>{{ t("detail") }}</span>
@@ -640,5 +647,10 @@ limitations under the License. -->
   .title {
     display: inline-block;
     width: 410px;
+  }
+
+  .link {
+    cursor: pointer;
+    color: #409eff;
   }
 </style>

--- a/src/views/dashboard/related/continuous-profiling/components/Policy.vue
+++ b/src/views/dashboard/related/continuous-profiling/components/Policy.vue
@@ -68,11 +68,17 @@ limitations under the License. -->
     </div>
     <div>
       <div class="label">{{ t("count") }}</div>
-      <el-input-number size="small" class="profile-input" :min="0" v-model="item.count" @change="changeParam" />
+      <div class="flex-h">
+        <el-input-number size="small" class="profile-input" :min="0" v-model="item.count" @change="changeParam" />
+        <span class="ml-5">s</span>
+      </div>
     </div>
     <div>
       <div class="label">{{ t("period") }}</div>
-      <el-input-number size="small" class="profile-input" :min="0" v-model="item.period" @change="changeParam" />
+      <div class="flex-h">
+        <el-input-number size="small" class="profile-input" :min="0" v-model="item.period" @change="changeParam" />
+        <span class="ml-5">s</span>
+      </div>
     </div>
     <div v-show="TYPES.includes(item.type)">
       <div class="label">{{ t("uriRegex") }}</div>

--- a/src/views/dashboard/related/log/Header.vue
+++ b/src/views/dashboard/related/log/Header.vue
@@ -107,8 +107,8 @@ limitations under the License. -->
         @change="addLabels('excludingKeywordsOfContent')"
       />
       <el-tooltip :content="t('keywordsOfContentLogTips')">
-        <span class="log-tips" v-show="!logStore.supportQueryLogsByKeywords">
-          <Icon icon="help" class="mr-5" />
+        <span v-show="!logStore.supportQueryLogsByKeywords">
+          <Icon iconName="help" class="mr-5" />
         </span>
       </el-tooltip>
     </div>


### PR DESCRIPTION
Video / Screenshot

https://github.com/apache/skywalking-booster-ui/assets/20871783/fe88bdcf-83b7-4003-9498-dba0ef5539e4

<img width="1833" alt="1" src="https://github.com/apache/skywalking-booster-ui/assets/20871783/469a96b7-8d28-46c1-baef-009f9d88bb89">

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
