### PR TITLE
init minTime to Infinity

### DIFF
--- a/src/views/dashboard/related/trace/components/Statistics.vue
+++ b/src/views/dashboard/related/trace/components/Statistics.vue
@@ -67,7 +67,7 @@ limitations under the License. -->
 
   function getSpanGroupData(groupspans: Span[], groupRef: StatisticsGroupRef): StatisticsSpan {
     let maxTime = 0;
-    let minTime = 0;
+    let minTime = Infinity;
     let sumTime = 0;
     const count = groupspans.length;
     groupspans.forEach((groupspan: Span) => {


### PR DESCRIPTION
 Instead of setting minTime to 0, it should be initialized with a larger value, such as Infinity or a value that is guaranteed to be larger than any valid time value in the data set. This will ensure that the minTime value is correctly calculated during the process.