### PR TITLE
fix: cannot access uninitialized variable on Safari

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@
  */
 import { createApp } from "vue";
 import App from "./App.vue";
-import router from "./router";
 import { store } from "./store";
 import components from "@/components";
 import i18n from "./locales";
@@ -33,6 +32,9 @@ app.use(store);
 mountApp();
 
 async function mountApp() {
+  await appStore.getActivateMenus();
   await appStore.queryOAPTimeInfo();
-  app.use(router).mount("#app");
+
+  const router = await import("./router");
+  app.use(router.default).mount("#app");
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { RouteRecordRaw } from "vue-router";
 import { createRouter, createWebHistory } from "vue-router";
 import { routesDashboard } from "./dashboard";
 import { routesMarketplace } from "./marketplace";
@@ -22,13 +21,7 @@ import { routesAlarm } from "./alarm";
 import routesLayers from "./layer";
 import { routesSettings } from "./settings";
 
-const routes: Array<RouteRecordRaw> = [
-  ...routesMarketplace,
-  ...routesLayers,
-  ...routesAlarm,
-  ...routesDashboard,
-  ...routesSettings,
-];
+const routes = [...routesMarketplace, ...routesLayers, ...routesAlarm, ...routesDashboard, ...routesSettings];
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { RouteRecordRaw } from "vue-router";
 import { createRouter, createWebHistory } from "vue-router";
 import { routesDashboard } from "./dashboard";
 import { routesMarketplace } from "./marketplace";
@@ -21,7 +22,13 @@ import { routesAlarm } from "./alarm";
 import routesLayers from "./layer";
 import { routesSettings } from "./settings";
 
-const routes = [...routesMarketplace, ...routesLayers, ...routesAlarm, ...routesDashboard, ...routesSettings];
+const routes: RouteRecordRaw[] = [
+  ...routesMarketplace,
+  ...routesLayers,
+  ...routesAlarm,
+  ...routesDashboard,
+  ...routesSettings,
+];
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/router/layer.ts
+++ b/src/router/layer.ts
@@ -18,9 +18,8 @@ import Layout from "@/layout/Index.vue";
 import { useAppStoreWithOut } from "@/store/modules/app";
 import type { MenuOptions } from "@/types/app";
 
-async function layerDashboards() {
+function layerDashboards() {
   const appStore = useAppStoreWithOut();
-  await appStore.getActivateMenus();
   const routes = appStore.allMenus.map((item: MenuOptions) => {
     const route: any = {
       path: "",
@@ -84,4 +83,4 @@ async function layerDashboards() {
   return routes;
 }
 
-export default await layerDashboards();
+export default layerDashboards();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,7 +79,7 @@ export default ({ mode }: ConfigEnv): UserConfig => {
       },
     },
     build: {
-      target: "esnext",
+      target: "es2015",
       outDir: OUTPUT_DIR,
       manifest: false,
       sourcemap: false,


### PR DESCRIPTION
As https://bugs.webkit.org/show_bug.cgi?id=242740, need to implement the menu routers with another solution for Safari.

Video 

https://github.com/apache/skywalking-booster-ui/assets/20871783/357a2ea4-ebad-4d00-9730-79084ece1993


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
