### PR TITLE
fix: update tooltip style to support multiple metrics scrolling view in a metrics graph

### DIFF
--- a/src/views/dashboard/graphs/Bar.vue
+++ b/src/views/dashboard/graphs/Bar.vue
@@ -82,7 +82,7 @@ limitations under the License. -->
         },
         enterable: true,
         confine: true,
-        extraCssText: "max-height: 300px; overflow: auto; border: none;",
+        extraCssText: "max-height:85%; overflow: auto;",
       },
       legend: {
         type: "scroll",

--- a/src/views/dashboard/graphs/Line.vue
+++ b/src/views/dashboard/graphs/Line.vue
@@ -99,7 +99,7 @@ limitations under the License. -->
       },
       enterable: true,
       confine: true,
-      extraCssText: "max-height: 300px; overflow: auto; border: none;",
+      extraCssText: "max-height:85%; overflow: auto;",
     };
     const tips = {
       formatter(params: any) {


### PR DESCRIPTION
Fixes tooltip style to support multiple metrics scrolling view in a metrics graph

Video

https://github.com/apache/skywalking-booster-ui/assets/20871783/8e5b5593-73c9-4992-8868-1a991b2910f9


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
