### PR TITLE
fix: set the height for trace widget

### DIFF
--- a/src/views/dashboard/related/trace/Index.vue
+++ b/src/views/dashboard/related/trace/Index.vue
@@ -59,5 +59,6 @@ limitations under the License. -->
     width: 100%;
     overflow: auto;
     min-width: 1200px;
+    height: calc(100% - 100px);
   }
 </style>


### PR DESCRIPTION
Video 

https://github.com/apache/skywalking-booster-ui/assets/20871783/98205eac-3e59-4c9b-9307-6c373a18ad15


Signed-0ff-by: Qiuxia Fan <qiuxiafan@apache.org>
