### PR TITLE
style: add underline for text widget

### DIFF
--- a/src/views/dashboard/controls/Text.vue
+++ b/src/views/dashboard/controls/Text.vue
@@ -42,6 +42,7 @@ limitations under the License. -->
         :style="{
           color: fontColor,
           fontSize: graph.fontSize + 'px',
+          textDecoration: 'underline',
         }"
       >
         {{ graph.content }}


### PR DESCRIPTION
Screenshot

<img width="625" alt="1" src="https://github.com/apache/skywalking-booster-ui/assets/20871783/a7f00340-0d8e-4e96-b669-127014649a76">


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
