### PR TITLE
fix: remove click event after unmounted

### DIFF
--- a/src/views/dashboard/controls/Tab.vue
+++ b/src/views/dashboard/controls/Tab.vue
@@ -120,7 +120,7 @@ limitations under the License. -->
   </div>
 </template>
 <script lang="ts">
-  import { ref, watch, defineComponent, toRefs } from "vue";
+  import { ref, watch, defineComponent, toRefs, onUnmounted } from "vue";
   import { useI18n } from "vue-i18n";
   import { useRoute } from "vue-router";
   import type { PropType } from "vue";
@@ -281,6 +281,10 @@ limitations under the License. -->
           needQuery.value = true;
         }
       }
+
+      onUnmounted(() => {
+        document.body.removeEventListener("click", handleClick, false);
+      });
 
       watch(
         () => (props.data.children || []).map((d: any) => d.expression),


### PR DESCRIPTION
The _handleClick_ function calls the _stopPropagation_, so we'd better remove the click events after component unmounted to prevent potential problems, such as adding click events to the _window_ or _document_ elsewhere won't work correctly.