### PR TITLE
fix(doc): fix the dev local port

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ npm install
 npm run dev
 ```
 
-The default UI address is `http://localhost:8080`.
+The default UI address is `http://localhost:3000`.
 
 # Contact Us
-* Mail list: **dev@skywalking.apache.org**. Mail to `dev-subscribe@skywalking.apache.org`, follow the reply to subscribe to the mail list.
-* Send `Request to join SkyWalking slack` mail to the mail list(`dev@skywalking.apache.org`), we will invite you in.
-* For Chinese speaker, send `[CN] Request to join SkyWalking slack` mail to the mail list(`dev@skywalking.apache.org`), we will invite you in.
-* Twitter, [ASFSkyWalking](https://twitter.com/AsfSkyWalking)
-* [bilibili B站 视频](https://space.bilibili.com/390683219)
+
+- Mail list: **dev@skywalking.apache.org**. Mail to `dev-subscribe@skywalking.apache.org`, follow the reply to subscribe to the mail list.
+- Send `Request to join SkyWalking slack` mail to the mail list(`dev@skywalking.apache.org`), we will invite you in.
+- For Chinese speaker, send `[CN] Request to join SkyWalking slack` mail to the mail list(`dev@skywalking.apache.org`), we will invite you in.
+- Twitter, [ASFSkyWalking](https://twitter.com/AsfSkyWalking)
+- [bilibili B 站 视频](https://space.bilibili.com/390683219)
 
 # License
 


### PR DESCRIPTION
The default UI address is `http://localhost:3000`.

```
  VITE v4.5.2  ready in 2551 ms

  ➜  Local:   http://localhost:3000/
```