### PR TITLE
fix: optimize search reset and format in marketplace

### DIFF
--- a/src/views/Marketplace.vue
+++ b/src/views/Marketplace.vue
@@ -78,6 +78,7 @@ limitations under the License. -->
   function searchMenus() {
     if (!searchText.value) {
       menus.value = appStore.allMenus;
+      currentItems.value = menus.value[0] || {};
       return;
     }
 
@@ -149,6 +150,7 @@ limitations under the License. -->
     border-right: 1px solid var(--sw-marketplace-border);
     align-content: flex-start;
     height: 100%;
+    width: 100%;
     overflow: auto;
   }
 


### PR DESCRIPTION
Fix optimize search reset and format in marketplace
- [x] Explain briefly why the bug exists and how to fix it.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes https://github.com/apache/skywalking/issues/12127

If reset and search, highlight the first menu.
<img width="890" alt="image" src="https://github.com/apache/skywalking-booster-ui/assets/22817918/566bfbee-09af-49cd-9c60-b4321cc34620">

Set width of category card to 100% to fix the right border
<img width="917" alt="image" src="https://github.com/apache/skywalking-booster-ui/assets/22817918/da4458cf-8556-40b1-ba38-805a8b11ffb7">
