### PR TITLE
Fix highlight keywords in logs

### DIFF
--- a/src/store/modules/log.ts
+++ b/src/store/modules/log.ts
@@ -53,9 +53,6 @@ export const logStore = defineStore({
     setLogCondition(data: Recordable) {
       this.conditions = { ...this.conditions, ...data };
     },
-    getLogKeywords() {
-      return this.conditions.keywordsOfContent;
-    },
     resetState() {
       this.logs = [];
       this.conditions = {

--- a/src/views/dashboard/related/log/LogTable/LogService.vue
+++ b/src/views/dashboard/related/log/LogTable/LogService.vue
@@ -61,7 +61,7 @@ limitations under the License. -->
     return (props.data.tags.find((d: { key: string; value: string }) => d.key === "level") || {}).value || "";
   });
   const highlightKeywords = (data: string) => {
-    const keywords = Object.values(logStore.getLogKeywords());
+    const keywords = Object.values(logStore.conditions.keywordsOfContent || {});
     const regex = new RegExp(keywords.join("|"), "gi");
     return data.replace(regex, (match) => `<span style="color: red">${match}</span>`);
   };


### PR DESCRIPTION
Fixes an error on displaying highlight words in logs.

Screenshot

<img width="1495" alt="1" src="https://github.com/user-attachments/assets/3384f753-8588-411b-85b8-ada277dd27af">

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
