### PR TITLE
Add support for case-insensitive search in the dashboard list

### DIFF
--- a/src/views/dashboard/List.vue
+++ b/src/views/dashboard/List.vue
@@ -612,7 +612,7 @@ limitations under the License. -->
   }
   function searchDashboards(pageIndex: number) {
     const list = JSON.parse(sessionStorage.getItem("dashboards") || "[]");
-    const arr = list.filter((d: { name: string }) => d.name.includes(searchText.value));
+    const arr = list.filter((d: { name: string }) => d.name.toLowerCase().includes(searchText.value.toLowerCase()));
 
     total.value = arr.length;
     dashboards.value = arr.filter(


### PR DESCRIPTION
Searching in the Dashboard List ignores case, which may make searching more convenient.

## Before
![kong-nothing](https://github.com/user-attachments/assets/5ade6d59-b2ac-4dfe-99e2-2b390aa14cab)


## After
![kong-has-value](https://github.com/user-attachments/assets/ac87b634-a8ed-4be0-a443-c5c25b966204)
