### PR TITLE
fix: hide entrances to unrelated dashboards  in top list

### DIFF
--- a/src/views/dashboard/graphs/TopList.vue
+++ b/src/views/dashboard/graphs/TopList.vue
@@ -35,7 +35,7 @@ limitations under the License. -->
           <div class="operation" @click="viewTrace(i)" v-show="![RefIdTypes[0].value].includes(refIdType)">
             <span>{{ t("viewTrace") }}</span>
           </div>
-          <div class="operation" @click="viewDashboard(i)">
+          <div class="operation" @click="viewDashboard(i)" v-show="props.config.valueRelatedDashboard">
             <span>{{ t("viewValueDashboard") }}</span>
           </div>
         </el-popover>


### PR DESCRIPTION
Video

https://github.com/user-attachments/assets/49acedd8-60fa-4ea4-83d3-9da3812280d6


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
