### PR TITLE
fix: releases an existing object URL 

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -37,8 +37,10 @@ export const saveFile = (data: any, name: string) => {
   tagA.download = name;
   tagA.style.display = "none";
   const blob = new Blob([newData]);
-  tagA.href = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(blob);
+  tagA.href = url;
   document.body.appendChild(tagA);
   tagA.click();
   document.body.removeChild(tagA);
+  URL.revokeObjectURL(url);
 };

--- a/src/views/dashboard/panel/Layout.vue
+++ b/src/views/dashboard/panel/Layout.vue
@@ -77,7 +77,7 @@ limitations under the License. -->
         }
       }
       async function queryMetrics() {
-        const widgets = [];
+        const widgets: LayoutConfig[] = [];
         for (const item of dashboardStore.layout) {
           if (item.type === WidgetType.Widget) {
             if (!ListChartTypes.includes(item.graph?.type || "")) {


### PR DESCRIPTION
Releases an existing object URL which was previously created by calling [URL.createObjectURL()](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static).

Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
