### PR TITLE
Fix: polish Async Profiling widget style

### DIFF
--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -263,6 +263,10 @@ div:has(> a.menu-title) {
   text-align: left !important;
 }
 
+.el-input--small .el-input__inner {
+  --el-input-inner-height: calc(var(--el-input-height, 24px));
+}
+
 html {
   &::view-transition-old(root),
   &::view-transition-new(root) {

--- a/src/views/dashboard/related/async-profiling/components/NewTask.vue
+++ b/src/views/dashboard/related/async-profiling/components/NewTask.vue
@@ -100,7 +100,6 @@ limitations under the License. -->
   import { useAsyncProfilingStore } from "@/store/modules/async-profiling";
   import { useSelectorStore } from "@/store/modules/selectors";
   import { ElMessage } from "element-plus";
-  import type { Option } from "@/types/app";
   import { DurationOptions, ProfilingEvents } from "./data";
 
   /* global defineEmits */


### PR DESCRIPTION
Reset height for the events selector.

Screenshot

<img width="1401" alt="1" src="https://github.com/user-attachments/assets/dec908e5-4d82-4427-8587-10841eb90e13">


Signed-off-by: Qiuxiafan<qiuxiafan@apache.org>
