### PR TITLE
Fix tooltips for metrics charts

### DIFF
--- a/src/views/dashboard/graphs/Bar.vue
+++ b/src/views/dashboard/graphs/Bar.vue
@@ -113,7 +113,7 @@ limitations under the License. -->
         },
         enterable: true,
         confine: true,
-        extraCssText: "max-height:85%; overflow: auto;",
+        extraCssText: "max-width: 100%; max-height: 75%; white-space: normal; overflow: auto;",
       },
       legend: {
         type: "scroll",

--- a/src/views/dashboard/graphs/Line.vue
+++ b/src/views/dashboard/graphs/Line.vue
@@ -111,7 +111,7 @@ limitations under the License. -->
       },
       enterable: true,
       confine: true,
-      extraCssText: "max-height:85%; overflow: auto;",
+      extraCssText: "max-width: 100%; max-height: 75%; white-space: normal; overflow: auto;",
     };
     const tips = {
       show: !props.config.noTooltips,


### PR DESCRIPTION
Fixes tooltips cannot completely display metrics information. It can be reproduced in demo environment.

Video

https://github.com/user-attachments/assets/37c9f523-31ac-4482-9e2c-6950d5cd6eab


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
