### PR TITLE
fix: time range when generate link

### DIFF
--- a/src/views/dashboard/components/WidgetLink.vue
+++ b/src/views/dashboard/components/WidgetLink.vue
@@ -126,7 +126,7 @@ limitations under the License. -->
         opt.auto = Number(f.value) * 60 * 60 * 1000;
       }
       if (f.step === TimeType.DAY_TIME) {
-        opt.auto = Number(f.value) * 60 * 60 * 60 * 1000;
+        opt.auto = Number(f.value) * 24 * 60 * 60 * 1000;
       }
     }
     const config = JSON.stringify(opt);


### PR DESCRIPTION
The time range was incorrect when the link was generated
![image](https://github.com/user-attachments/assets/85c52b62-fdd0-4cbd-a1ac-8dbcb56df108)
