### PR TITLE
feat: enhance the async-profiling duration options

### DIFF
--- a/src/locales/lang/en.ts
+++ b/src/locales/lang/en.ts
@@ -401,5 +401,8 @@ const msg = {
   recordsTTL: "Records TTL",
   clusterNodes: "Cluster Nodes",
   debuggingConfigDump: "Dump Effective Configurations",
+  customDuration: "Custom Duration",
+  maxDuration: "Max Duration",
+  minutes: "Minutes",
 };
 export default msg;

--- a/src/locales/lang/es.ts
+++ b/src/locales/lang/es.ts
@@ -401,5 +401,8 @@ const msg = {
   recordsTTL: "Records TTL",
   clusterNodes: "Cluster Nodes",
   debuggingConfigDump: "Dump Effective Configurations",
+  customDuration: "Duración Personalizada",
+  maxDuration: "Duración Máxima",
+  minutes: "Minutos",
 };
 export default msg;

--- a/src/locales/lang/zh.ts
+++ b/src/locales/lang/zh.ts
@@ -399,5 +399,8 @@ const msg = {
   recordsTTL: "Records TTL",
   clusterNodes: "集群节点",
   debuggingConfigDump: "转储有效配置",
+  customDuration: "自定义时长",
+  maxDuration: "最大时长",
+  minutes: "分钟",
 };
 export default msg;

--- a/src/views/dashboard/related/async-profiling/components/NewTask.vue
+++ b/src/views/dashboard/related/async-profiling/components/NewTask.vue
@@ -31,6 +31,19 @@ limitations under the License. -->
     <div>
       <div class="label">{{ t("duration") }}</div>
       <Radio class="mb-5" :value="duration" :options="DurationOptions" @change="changeDuration" />
+      <div v-if="duration === 'custom'" class="custom-duration">
+        <div class="label">{{ t("customDuration") }} ({{ t("seconds") }})</div>
+        <el-input
+          size="small"
+          class="profile-input"
+          v-model="customDurationSeconds"
+          type="number"
+          :min="1"
+          :max="900"
+          placeholder="Enter duration in seconds (1-900)"
+        />
+        <div class="hint">{{ t("maxDuration") }}: 900 {{ t("seconds") }} (15 {{ t("minutes") }})</div>
+      </div>
     </div>
     <div>
       <div class="label">{{ t("profilingEvents") }}</div>
@@ -113,6 +126,7 @@ limitations under the License. -->
   const execArgs = ref<string>("");
   const loading = ref<boolean>(false);
   const PartofEvents = [ProfilingEvents[3], ProfilingEvents[4], ProfilingEvents[5]];
+  const customDurationSeconds = ref<number>(60);
 
   function changeDuration(val: string) {
     duration.value = val;
@@ -138,10 +152,22 @@ limitations under the License. -->
   }
 
   async function createTask() {
+    let finalDuration: number;
+
+    if (duration.value === "custom") {
+      if (!customDurationSeconds.value || customDurationSeconds.value < 1 || customDurationSeconds.value > 900) {
+        ElMessage.error("Please enter a valid duration between 1 and 900 seconds");
+        return;
+      }
+      finalDuration = customDurationSeconds.value;
+    } else {
+      finalDuration = Number(duration.value) * 60;
+    }
+
     const params = {
       serviceId: selectorStore.currentService.id,
       serviceInstanceIds: serviceInstanceIds.value,
-      duration: Number(duration.value) * 60,
+      duration: finalDuration,
       events: asyncEvents.value,
       execArgs: execArgs.value,
     };
@@ -183,5 +209,14 @@ limitations under the License. -->
   .create-task-btn {
     width: 600px;
     margin-top: 50px;
+  }
+
+  .custom-duration {
+    margin-top: 10px;
+  }
+
+  .hint {
+    font-size: $font-size-smaller;
+    color: var(--text-color-placeholder);
   }
 </style>

--- a/src/views/dashboard/related/async-profiling/components/data.ts
+++ b/src/views/dashboard/related/async-profiling/components/data.ts
@@ -16,9 +16,12 @@
  */
 
 export const DurationOptions = [
+  { value: "0.5", label: "30 sec" },
+  { value: "1", label: "1 min" },
   { value: "5", label: "5 min" },
   { value: "10", label: "10 min" },
   { value: "15", label: "15 min" },
+  { value: "custom", label: "Custom" },
 ];
 
 export const ProfilingEvents = ["CPU", "ALLOC", "LOCK", "WALL", "CTIMER", "ITIMER"];


### PR DESCRIPTION
feat: https://github.com/apache/skywalking/issues/13282

- Add 30-second and 1-minute options to the existing choices.
- Add custom duration input: [1, 900] seconds.