### PR TITLE
fix: optimize appearing the wrong prompt by pop-up for the HTTP environments in copy function

### DIFF
--- a/src/utils/__tests__/copy.spec.ts
+++ b/src/utils/__tests__/copy.spec.ts
@@ -29,6 +29,11 @@ const mockClipboard = {
   writeText: vi.fn(),
 };
 
+// Mock location
+const mockLocation = {
+  protocol: "https:",
+};
+
 describe("copy utility function", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,13 +43,19 @@ describe("copy utility function", () => {
       value: mockClipboard,
       writable: true,
     });
+
+    // Mock location
+    Object.defineProperty(window, "location", {
+      value: mockLocation,
+      writable: true,
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("should copy text successfully and show success notification", async () => {
+  it("should copy text successfully and show success notification in HTTPS", async () => {
     const testText = "test text to copy";
     mockClipboard.writeText.mockResolvedValue(undefined);
 
@@ -58,6 +69,43 @@ describe("copy utility function", () => {
       title: "Success",
       message: "Copied",
       type: "success",
+    });
+  });
+
+  it("should show error notification for HTTP protocol", () => {
+    const testText = "test text to copy";
+
+    // Set protocol to HTTP
+    Object.defineProperty(window, "location", {
+      value: { protocol: "http:" },
+      writable: true,
+    });
+
+    copy(testText);
+
+    expect(ElNotification).toHaveBeenCalledWith({
+      title: "Error",
+      message: "Clipboard is not supported in HTTP environments",
+      type: "warning",
+    });
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("should show error notification when clipboard is not available", () => {
+    const testText = "test text to copy";
+
+    // Remove clipboard from navigator
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      writable: true,
+    });
+
+    copy(testText);
+
+    expect(ElNotification).toHaveBeenCalledWith({
+      title: "Error",
+      message: "Clipboard is not supported",
+      type: "warning",
     });
   });
 
@@ -157,18 +205,47 @@ describe("copy utility function", () => {
     expect(ElNotification).toHaveBeenCalledTimes(3);
   });
 
-  it("should handle clipboard not available", async () => {
+  it("should handle HTTP protocol and clipboard not available", () => {
     const testText = "test text";
 
-    // Remove clipboard from navigator
+    // Set protocol to HTTP
+    Object.defineProperty(window, "location", {
+      value: { protocol: "http:" },
+      writable: true,
+    });
+
+    copy(testText);
+
+    // Should show HTTP error, not clipboard error
+    expect(ElNotification).toHaveBeenCalledWith({
+      title: "Error",
+      message: "Clipboard is not supported in HTTP environments",
+      type: "warning",
+    });
+  });
+
+  it("should handle file protocol", () => {
+    const testText = "test text";
+
+    // Set protocol to file and ensure clipboard is not available
+    Object.defineProperty(window, "location", {
+      value: { protocol: "file:" },
+      writable: true,
+    });
+
+    // Remove clipboard from navigator for this test
     Object.defineProperty(navigator, "clipboard", {
       value: undefined,
       writable: true,
     });
 
-    // Should not throw error
-    expect(() => {
-      copy(testText);
-    }).not.toThrow();
+    copy(testText);
+
+    // Should show clipboard not supported error
+    expect(ElNotification).toHaveBeenCalledWith({
+      title: "Error",
+      message: "Clipboard is not supported",
+      type: "warning",
+    });
   });
 });

--- a/src/utils/__tests__/copy.spec.ts
+++ b/src/utils/__tests__/copy.spec.ts
@@ -84,7 +84,7 @@ describe("copy utility function", () => {
     copy(testText);
 
     expect(ElNotification).toHaveBeenCalledWith({
-      title: "Error",
+      title: "Warning",
       message: "Clipboard is not supported in HTTP environments",
       type: "warning",
     });
@@ -103,7 +103,7 @@ describe("copy utility function", () => {
     copy(testText);
 
     expect(ElNotification).toHaveBeenCalledWith({
-      title: "Error",
+      title: "Warning",
       message: "Clipboard is not supported",
       type: "warning",
     });
@@ -121,7 +121,7 @@ describe("copy utility function", () => {
 
     expect(mockClipboard.writeText).toHaveBeenCalledWith(testText);
     expect(ElNotification).toHaveBeenCalledWith({
-      title: "Error",
+      title: "Warning",
       message: errorMessage,
       type: "warning",
     });
@@ -218,7 +218,7 @@ describe("copy utility function", () => {
 
     // Should show HTTP error, not clipboard error
     expect(ElNotification).toHaveBeenCalledWith({
-      title: "Error",
+      title: "Warning",
       message: "Clipboard is not supported in HTTP environments",
       type: "warning",
     });
@@ -243,7 +243,7 @@ describe("copy utility function", () => {
 
     // Should show clipboard not supported error
     expect(ElNotification).toHaveBeenCalledWith({
-      title: "Error",
+      title: "Warning",
       message: "Clipboard is not supported",
       type: "warning",
     });

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -18,8 +18,20 @@
 import { ElNotification } from "element-plus";
 
 export default (text: string): void => {
+  if (location.protocol === "http:") {
+    ElNotification({
+      title: "Error",
+      message: "Clipboard is not supported in HTTP environments",
+      type: "warning",
+    });
+    return;
+  }
   if (!navigator.clipboard) {
-    console.error("Clipboard is not supported");
+    ElNotification({
+      title: "Error",
+      message: "Clipboard is not supported",
+      type: "warning",
+    });
     return;
   }
   navigator.clipboard

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -20,7 +20,7 @@ import { ElNotification } from "element-plus";
 export default (text: string): void => {
   if (location.protocol === "http:") {
     ElNotification({
-      title: "Error",
+      title: "Warning",
       message: "Clipboard is not supported in HTTP environments",
       type: "warning",
     });
@@ -28,7 +28,7 @@ export default (text: string): void => {
   }
   if (!navigator.clipboard) {
     ElNotification({
-      title: "Error",
+      title: "Warning",
       message: "Clipboard is not supported",
       type: "warning",
     });
@@ -45,7 +45,7 @@ export default (text: string): void => {
     })
     .catch((err) => {
       ElNotification({
-        title: "Error",
+        title: "Warning",
         message: err,
         type: "warning",
       });


### PR DESCRIPTION
Related https://github.com/apache/skywalking/discussions/13418

Video

https://github.com/user-attachments/assets/9ce692f1-d61e-4cde-81e3-9cf29f25daad


Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>

