### PR TITLE
Add WeChat and Alipay Mini Program i18n menu entries

### DIFF
--- a/src/locales/lang/menus/en.ts
+++ b/src/locales/lang/menus/en.ts
@@ -82,6 +82,12 @@ const titles = {
   mobile_ios: "iOS",
   mobile_ios_desc:
     "iOS and iPadOS app monitoring via OpenTelemetry Swift SDK. Provides HTTP performance, MetricKit daily stats, and crash diagnostics.",
+  mobile_wechat_mini_program: "WeChat Mini Program",
+  mobile_wechat_mini_program_desc:
+    "WeChat Mini Program monitoring via the mini-program-monitor SDK. Launch / render / route / script / package-load perf, request latency percentiles, error counts, per-page breakdowns, plus trace drill-down for outbound HTTP.",
+  mobile_alipay_mini_program: "Alipay Mini Program",
+  mobile_alipay_mini_program_desc:
+    "Alipay Mini Program monitoring via the mini-program-monitor SDK. Lifecycle-based launch / render approximations, request latency percentiles, error counts, per-page breakdowns, plus trace drill-down for outbound HTTP.",
   // Gateway
   gateway: "Gateway",
   gateway_desc:

--- a/src/locales/lang/menus/es.ts
+++ b/src/locales/lang/menus/es.ts
@@ -83,6 +83,12 @@ const titles = {
   mobile_ios: "iOS",
   mobile_ios_desc:
     "iOS and iPadOS app monitoring via OpenTelemetry Swift SDK. Provides HTTP performance, MetricKit daily stats, and crash diagnostics.",
+  mobile_wechat_mini_program: "WeChat Mini Program",
+  mobile_wechat_mini_program_desc:
+    "WeChat Mini Program monitoring via the mini-program-monitor SDK. Launch / render / route / script / package-load perf, request latency percentiles, error counts, per-page breakdowns, plus trace drill-down for outbound HTTP.",
+  mobile_alipay_mini_program: "Alipay Mini Program",
+  mobile_alipay_mini_program_desc:
+    "Alipay Mini Program monitoring via the mini-program-monitor SDK. Lifecycle-based launch / render approximations, request latency percentiles, error counts, per-page breakdowns, plus trace drill-down for outbound HTTP.",
   // Gateway
   gateway: "Puerta",
   gateway_desc:

--- a/src/locales/lang/menus/zh.ts
+++ b/src/locales/lang/menus/zh.ts
@@ -74,6 +74,12 @@ const titles = {
   mobile_ios: "iOS",
   mobile_ios_desc:
     "通过 OpenTelemetry Swift SDK 提供 iOS 和 iPadOS 应用监控，包括 HTTP 性能、MetricKit 每日统计和崩溃诊断。",
+  mobile_wechat_mini_program: "微信小程序",
+  mobile_wechat_mini_program_desc:
+    "通过 mini-program-monitor SDK 提供微信小程序监控。包括启动 / 渲染 / 路由 / 脚本 / 分包加载性能、请求延迟分位数、错误计数、按页面细分，以及出站 HTTP 的链路追踪下钻。",
+  mobile_alipay_mini_program: "支付宝小程序",
+  mobile_alipay_mini_program_desc:
+    "通过 mini-program-monitor SDK 提供支付宝小程序监控。包括基于生命周期的启动 / 渲染近似值、请求延迟分位数、错误计数、按页面细分，以及出站 HTTP 的链路追踪下钻。",
   // Gateway
   gateway: "网关",
   gateway_desc: "API网关是位于客户端和后端服务集合之间的API管理工具。",


### PR DESCRIPTION
### Feature description

SWIP-12 landed in [apache/skywalking#13835](https://github.com/apache/skywalking/pull/13835), adding two new sub-menus under **Mobile Monitoring**:

- **Mobile > WeChat Mini Program** (layer `WECHAT_MINI_PROGRAM`, `i18nKey: mobile_wechat_mini_program`)
- **Mobile > Alipay Mini Program** (layer `ALIPAY_MINI_PROGRAM`, `i18nKey: mobile_alipay_mini_program`)

Without the locale entries, the menu labels fall back to the raw `i18nKey` string in the UI. Add translations for `en` / `zh` / `es`, matching the existing `mobile_ios` pattern.

- [x] If this is non-trivial feature, paste the links/URLs to the design doc. — [SWIP-12](https://github.com/apache/skywalking/blob/master/docs/en/swip/SWIP-12.md)
- [ ] Update the documentation to include this new feature. — N/A, booster-ui has no doc change
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature. — N/A, i18n-only
- [ ] If it's UI related, attach the screenshots below.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-booster-ui/blob/main/CHANGES.md).